### PR TITLE
feat(pages): configure fallback, csr and ssr

### DIFF
--- a/awesome-front/src/routes/+layout.ts
+++ b/awesome-front/src/routes/+layout.ts
@@ -1,1 +1,2 @@
-export const prerender = true;
+export const ssr = false;
+export const csr = true;

--- a/awesome-front/svelte.config.js
+++ b/awesome-front/svelte.config.js
@@ -11,7 +11,7 @@ const config = {
             // these options are set automatically — see below
             pages: 'build',
             assets: 'build',
-            fallback: null,
+            fallback: '404.html',
             precompress: false,
             strict: true,
             paths: {


### PR DESCRIPTION
Configurations : 
Server Side Rendering : false
Client Side Rendering : true

Dans le svelte.config.ts ajout d'un fallback, pour que github utilise ce fallback lorsqu'il ne trouve pas la page (404.html est une copie de index.html)